### PR TITLE
Improvements and Refactoring

### DIFF
--- a/contracts/IMultiSigWallet.sol
+++ b/contracts/IMultiSigWallet.sol
@@ -72,7 +72,7 @@ interface IMultiSigWallet is IMultiSigWalletTypes {
      * @dev Emitted when a transaction expiration time is configured.
      * @param newExpirationTime The new value of the expiration time.
      */
-    event CofigureExpirationTime(uint256 newExpirationTime);
+    event ConfigureExpirationTime(uint256 newExpirationTime);
 
     /**
      * @dev Emitted when a transaction cooldown time is configured.
@@ -163,7 +163,7 @@ interface IMultiSigWallet is IMultiSigWalletTypes {
     /**
      * @dev Configures the expiration time that will be applied to new transactions.
      *
-     * Emits a {CofigureExpirationTime} event.
+     * Emits a {ConfigureExpirationTime} event.
      *
      * @param newExpirationTime The new value of the expiration time.
      */

--- a/contracts/IMultiSigWallet.sol
+++ b/contracts/IMultiSigWallet.sol
@@ -3,7 +3,7 @@
 pragma solidity 0.8.16;
 
 /**
- * @title IMultiSigWalletTypes interface
+ * @title MultiSigWallet types interface
  * @author CloudWalk Inc.
  */
 interface IMultiSigWalletTypes {

--- a/contracts/IMultiSigWallet.sol
+++ b/contracts/IMultiSigWallet.sol
@@ -24,7 +24,6 @@ interface IMultiSigWalletTypes {
  * @dev The interface of the multi-signature wallet contract.
  */
 interface IMultiSigWallet is IMultiSigWalletTypes {
-
     // --------------------------- Events ---------------------------
 
     /**
@@ -70,16 +69,16 @@ interface IMultiSigWallet is IMultiSigWalletTypes {
     event ConfigureOwners(address[] newOwners, uint256 newRequiredApprovals);
 
     /**
-     * @dev Emitted when a transaction cooldown time is configured.
-     * @param newCooldownTime The new value of the cooldown time.
-     */
-    event ConfigureCooldownTime(uint256 newCooldownTime);
-
-    /**
      * @dev Emitted when a transaction expiration time is configured.
      * @param newExpirationTime The new value of the expiration time.
      */
     event CofigureExpirationTime(uint256 newExpirationTime);
+
+    /**
+     * @dev Emitted when a transaction cooldown time is configured.
+     * @param newCooldownTime The new value of the cooldown time.
+     */
+    event ConfigureCooldownTime(uint256 newCooldownTime);
 
     // ------------------------- Functions --------------------------
 
@@ -162,6 +161,15 @@ interface IMultiSigWallet is IMultiSigWalletTypes {
     function configureOwners(address[] memory newOwners, uint256 newRequiredApprovals) external;
 
     /**
+     * @dev Configures the expiration time that will be applied to new transactions.
+     *
+     * Emits a {CofigureExpirationTime} event.
+     *
+     * @param newExpirationTime The new value of the expiration time.
+     */
+    function configureExpirationTime(uint256 newExpirationTime) external;
+
+    /**
      * @dev Configures the cooldown time that will be applied to new transactions.
      *
      * Emits a {ConfigureCooldownTime} event.
@@ -171,13 +179,10 @@ interface IMultiSigWallet is IMultiSigWalletTypes {
     function configureCooldownTime(uint256 newCooldownTime) external;
 
     /**
-     * @dev Configures the expiration time that will be applied to new transactions.
-     *
-     * Emits a {CofigureExpirationTime} event.
-     *
-     * @param newExpirationTime The new value of the expiration time.
+     * @dev Returns the number of approvals for a transaction.
+     * @param txId The Id of the transaction to check.
      */
-    function configureExpirationTime(uint256 newExpirationTime) external;
+    function getApprovalCount(uint256 txId) external view returns (uint256);
 
     /**
      * @dev Returns the approval status of a transaction.
@@ -188,10 +193,17 @@ interface IMultiSigWallet is IMultiSigWalletTypes {
     function getApprovalStatus(uint256 txId, address owner) external view returns (bool);
 
     /**
-     * @dev Returns the number of approvals for a transaction.
-     * @param txId The Id of the transaction to check.
+     * @dev Returns a single transaction.
+     * @param txId The Id of the transaction to return.
      */
-    function getApprovalCount(uint256 txId) external view returns (uint256);
+    function getTransaction(uint256 txId) external view returns (Transaction memory);
+
+    /**
+     * @dev Returns an array of transactions.
+     * @param txId The Id of the first transaction in the range to return.
+     * @param limit The maximum number of transactions in the range to return.
+     */
+    function getTransactions(uint256 txId, uint256 limit) external view returns (Transaction[] memory);
 
     /**
      * @dev Returns an array of wallet owners.
@@ -204,30 +216,17 @@ interface IMultiSigWallet is IMultiSigWalletTypes {
     function requiredApprovals() external view returns (uint256);
 
     /**
-     * @dev Returns an array of transactions.
-     * @param txId The Id of the first transaction in the range to return.
-     * @param limit The maximum number of transactions in the range to return.
-     */
-    function getTransactions(uint256 txId, uint256 limit) external view returns (Transaction[] memory);
-
-    /**
-     * @dev Returns a single transaction.
-     * @param txId The Id of the transaction to return.
-     */
-    function getTransaction(uint256 txId) external view returns (Transaction memory);
-
-    /**
      * @dev Returns the total number of transactions in the wallet.
      */
     function transactionCount() external view returns (uint256);
 
     /**
-     * @dev Returns the configured cooldown time.
-     */
-    function cooldownTime() external view returns (uint256);
-
-    /**
      * @dev Returns the configured expiration time.
      */
     function expirationTime() external view returns (uint256);
+
+    /**
+     * @dev Returns the configured cooldown time.
+     */
+    function cooldownTime() external view returns (uint256);
 }

--- a/contracts/IMultiSigWallet.sol
+++ b/contracts/IMultiSigWallet.sol
@@ -11,9 +11,9 @@ interface IMultiSigWalletTypes {
     struct Transaction {
         address to;         // The address of the transaction receiver.
         uint256 value;      // The value in native tokens to be sent along with the transaction.
-        bool executed;      // The execution status of the transaction.
         uint256 cooldown;   // The timestamp before which the transaction cannot be executed.
         uint256 expiration; // The timestamp after which the transaction cannot be executed.
+        bool executed;      // The execution status of the transaction. True if executed.
         bytes data;         // The data to be sent along with the transaction.
     }
 }
@@ -37,7 +37,7 @@ interface IMultiSigWallet is IMultiSigWalletTypes {
      * @dev Emitted when a transaction is submitted.
      * @param txId The id of the submitted transaction.
      */
-    event Submit(uint256 indexed txId);
+    event Submit(address indexed owner, uint256 indexed txId);
 
     /**
      * @dev Emitted when a transaction is approved.
@@ -57,26 +57,26 @@ interface IMultiSigWallet is IMultiSigWalletTypes {
      * @dev Emitted when a transaction is executed.
      * @param txId The id of the executed transaction.
      */
-    event Execute(uint256 indexed txId);
+    event Execute(address indexed owner, uint256 indexed txId);
 
     /**
      * @dev Emitted when a wallet owners and required approvals amount are changed.
      * @param newOwners The array of addresses that became wallet owners.
      * @param newRequiredApprovals The new amount of approvals required to execute a transaction.
      */
-    event Configure(address[] newOwners, uint256 newRequiredApprovals);
+    event ConfigureOwners(address[] newOwners, uint256 newRequiredApprovals);
 
     /**
      * @dev Emitted when the cooldown time of transactions is changed.
      * @param newCooldownTime The new time of the cooldown.
      */
-    event CooldownTimeUpdate(uint256 newCooldownTime);
+    event ConfigureCooldownTime(uint256 newCooldownTime);
 
     /**
      * @dev Emitted when expiration time of transactions is changed.
      * @param newExpirationTime The new time of the transaction expiration.
      */
-    event ExpirationTimeUpdate(uint256 newExpirationTime);
+    event CofigureExpirationTime(uint256 newExpirationTime);
 
     // -------------------- Functions --------------------------------
 
@@ -90,9 +90,9 @@ interface IMultiSigWallet is IMultiSigWalletTypes {
      * @param txData The data of the transaction.
      */
     function submit(
-        address receiver,
-        uint256 txValue,
-        bytes calldata txData
+        address to,
+        uint256 value,
+        bytes calldata data
     ) external;
 
     /**
@@ -106,9 +106,9 @@ interface IMultiSigWallet is IMultiSigWalletTypes {
      * @param txData The data of the transaction.
      */
     function submitAndApprove(
-        address receiver,
-        uint256 txValue,
-        bytes calldata txData
+        address to,
+        uint256 value,
+        bytes calldata data
     ) external;
 
     /**
@@ -156,7 +156,7 @@ interface IMultiSigWallet is IMultiSigWalletTypes {
      * @param newOwners The array of addresses to become wallet owners.
      * @param newRequiredApprovals The amount of approvals needed to execute a transaction.
      */
-    function configure(address[] memory newOwners, uint256 newRequiredApprovals) external;
+    function configureOwners(address[] memory newOwners, uint256 newRequiredApprovals) external;
 
     /**
      * @dev Sets new cooldown time of transactions.
@@ -167,7 +167,7 @@ interface IMultiSigWallet is IMultiSigWalletTypes {
      * 
      * @param newCooldownTime The new time of the cooldown.
      */
-    function updateCooldownTime(uint256 newCooldownTime) external;
+    function configureCooldownTime(uint256 newCooldownTime) external;
 
     /**
      * @dev Sets new expiration time of transactions.
@@ -178,7 +178,7 @@ interface IMultiSigWallet is IMultiSigWalletTypes {
      * 
      * @param newExpirationTime The new time of the expiration.
      */
-    function updateExpirationTime(uint256 newExpirationTime) external;
+    function configureExpirationTime(uint256 newExpirationTime) external;
 
     /**
      * @dev Checks if a transaction is approved by a wallet owner.
@@ -186,7 +186,7 @@ interface IMultiSigWallet is IMultiSigWalletTypes {
      * @param owner The address of the wallet owner to check.
      * @return True if the transaction is approved.
      */
-    function getApproval(uint256 txId, address owner) external view returns (bool);
+    function getApprovalStatus(uint256 txId, address owner) external view returns (bool);
 
     /**
      * @dev Returns the number of approvals for a transaction.
@@ -209,10 +209,7 @@ interface IMultiSigWallet is IMultiSigWalletTypes {
      * @param txId The id of the first transaction in the range to return.
      * @param limit The maximum number of transactions in the range to return.
      */
-    function getTransactions(uint256 txId, uint256 limit)
-        external
-        view
-        returns (Transaction[] memory resultTransactions);
+    function getTransactions(uint256 txId, uint256 limit) external view returns (Transaction[] memory);
 
     /**
      * @dev Returns the details of a transaction.
@@ -229,9 +226,11 @@ interface IMultiSigWallet is IMultiSigWalletTypes {
      * @dev Returns the current cooldown time of transactions.
      */
     function transactionCooldownTime() external view returns (uint256);
+    function cooldownTime() external view returns (uint256);
 
     /**
      * @dev Returns the current expiration time of transactions.
      */
     function transactionExpirationTime() external view returns (uint256);
+    function expirationTime() external view returns (uint256);
 }

--- a/contracts/IMultiSigWallet.sol
+++ b/contracts/IMultiSigWallet.sol
@@ -3,7 +3,7 @@
 pragma solidity 0.8.16;
 
 /**
- * @title MultiSigWallet types interface
+ * @title IMultiSigWalletTypes interface
  * @author CloudWalk Inc.
  */
 interface IMultiSigWalletTypes {
@@ -21,73 +21,76 @@ interface IMultiSigWalletTypes {
 /**
  * @title MultiSigWallet interface
  * @author CloudWalk Inc.
- * @dev The interface of the multisignature wallet contract.
+ * @dev The interface of the multi-signature wallet contract.
  */
 interface IMultiSigWallet is IMultiSigWalletTypes {
-    // -------------------- Events -----------------------------------
+
+    // --------------------------- Events ---------------------------
 
     /**
      * @dev Emitted when native tokens are deposited to the contract.
-     * @param sender The address of the native token sender.
+     * @param sender The address of the native tokens sender.
      * @param amount The amount of deposited native tokens.
      */
     event Deposit(address indexed sender, uint256 amount);
 
     /**
-     * @dev Emitted when a transaction is submitted.
-     * @param txId The id of the submitted transaction.
+     * @dev Emitted when a new transaction is submitted.
+     * @param owner The address that submitted the transaction.
+     * @param txId The Id of the transaction that is submitted.
      */
     event Submit(address indexed owner, uint256 indexed txId);
 
     /**
      * @dev Emitted when a transaction is approved.
      * @param owner The address that approved the transaction.
-     * @param txId The id of the transaction that is approved.
+     * @param txId The Id of the transaction that is approved.
      */
     event Approve(address indexed owner, uint256 indexed txId);
 
     /**
      * @dev Emitted when a transaction approval is revoked.
      * @param owner The address that revoked the transaction approval.
-     * @param txId The id of the transaction whose approval is revoked.
+     * @param txId The Id of the transaction whose approval is revoked.
      */
     event Revoke(address indexed owner, uint256 indexed txId);
 
     /**
      * @dev Emitted when a transaction is executed.
-     * @param txId The id of the executed transaction.
+     * @param owner The address that executed the transaction.
+     * @param txId The Id of the transaction that is executed.
      */
     event Execute(address indexed owner, uint256 indexed txId);
 
     /**
-     * @dev Emitted when a wallet owners and required approvals amount are changed.
-     * @param newOwners The array of addresses that became wallet owners.
-     * @param newRequiredApprovals The new amount of approvals required to execute a transaction.
+     * @dev Emitted when wallet owners are configured.
+     * @param newOwners The array of addresses that became the wallet owners.
+     * @param newRequiredApprovals The new number of approvals required to execute a transaction.
      */
     event ConfigureOwners(address[] newOwners, uint256 newRequiredApprovals);
 
     /**
-     * @dev Emitted when the cooldown time of transactions is changed.
-     * @param newCooldownTime The new time of the cooldown.
+     * @dev Emitted when a transaction cooldown time is configured.
+     * @param newCooldownTime The new value of the cooldown time.
      */
     event ConfigureCooldownTime(uint256 newCooldownTime);
 
     /**
-     * @dev Emitted when expiration time of transactions is changed.
-     * @param newExpirationTime The new time of the transaction expiration.
+     * @dev Emitted when a transaction expiration time is configured.
+     * @param newExpirationTime The new value of the expiration time.
      */
     event CofigureExpirationTime(uint256 newExpirationTime);
 
-    // -------------------- Functions --------------------------------
+    // ------------------------- Functions --------------------------
 
     /**
      * @dev Submits a new transaction.
      *
      * Emits a {Submit} event.
      *
-     * @param receiver The address of the transaction receiver.
-     * @param txValue The value of the transaction in native tokens.
-     * @param txData The data of the transaction.
+     * @param to The address of the transaction receiver.
+     * @param value The value of the transaction in native tokens.
+     * @param data The input data of the transaction.
      */
     function submit(
         address to,
@@ -101,9 +104,9 @@ interface IMultiSigWallet is IMultiSigWalletTypes {
      * Emits a {Submit} event.
      * Emits an {Approve} event.
      *
-     * @param receiver The address of the transaction receiver.
-     * @param txValue The value of the transaction in native tokens.
-     * @param txData The data of the transaction.
+     * @param to The address of the transaction receiver.
+     * @param value The value of the transaction in native tokens.
+     * @param data The input data of the transaction.
      */
     function submitAndApprove(
         address to,
@@ -116,7 +119,7 @@ interface IMultiSigWallet is IMultiSigWalletTypes {
      *
      * Emits an {Approve} event.
      *
-     * @param txId The id of the transaction to approve.
+     * @param txId The Id of the transaction to approve.
      */
     function approve(uint256 txId) external;
 
@@ -126,63 +129,59 @@ interface IMultiSigWallet is IMultiSigWalletTypes {
      * Emits an {Approve} event.
      * Emits an {Execute} event.
      *
-     * @param txId The id of the transaction to approve and execute.
+     * @param txId The Id of the transaction to approve and execute.
      */
     function approveAndExecute(uint256 txId) external;
 
     /**
-     * @dev Executes a previously submitted transaction by calling its destination address.
+     * @dev Executes a previously submitted transaction.
      *
      * Emits an {Execute} event.
      *
-     * @param txId The id of the transaction to execute.
+     * @param txId The Id of the transaction to execute.
      */
     function execute(uint256 txId) external;
 
     /**
-     * @dev Revokes the approved status of a transaction previously granted by the caller.
+     * @dev Revokes a previously approved status of a transaction.
      *
      * Emits a {Revoke} event.
      *
-     * @param txId The id of the transaction to revoke the approval.
+     * @param txId The Id of the transaction to revoke the approved status.
      */
     function revoke(uint256 txId) external;
 
     /**
-     * @dev Sets wallet owners and amount of required approvals.
+     * @dev Configures wallet owners.
      *
-     * Emits a {NewWalletParamaters} event.
+     * Emits a {ConfigureOwners} event.
      *
-     * @param newOwners The array of addresses to become wallet owners.
-     * @param newRequiredApprovals The amount of approvals needed to execute a transaction.
+     * @param newOwners The array of addresses to become the wallet owners.
+     * @param newRequiredApprovals The new number of approvals required to execute a transaction.
      */
     function configureOwners(address[] memory newOwners, uint256 newRequiredApprovals) external;
 
     /**
-     * @dev Sets new cooldown time of transactions.
+     * @dev Configures the cooldown time that will be applied to new transactions.
      *
-     * The cooldown time is the time that need to pass after submitting a transaction before it can be executed.
-     * 
-     * Emits a {CooldownTimeUpdate} event.
-     * 
-     * @param newCooldownTime The new time of the cooldown.
+     * Emits a {ConfigureCooldownTime} event.
+     *
+     * @param newCooldownTime The new value of the cooldown time.
      */
     function configureCooldownTime(uint256 newCooldownTime) external;
 
     /**
-     * @dev Sets new expiration time of transactions.
+     * @dev Configures the expiration time that will be applied to new transactions.
      *
-     * The expiration time is the time after submitting a transaction before which it can be executed.
-     * 
-     * Emits a {ExpirationTimeUpdate} event.
-     * 
-     * @param newExpirationTime The new time of the expiration.
+     * Emits a {CofigureExpirationTime} event.
+     *
+     * @param newExpirationTime The new value of the expiration time.
      */
     function configureExpirationTime(uint256 newExpirationTime) external;
 
     /**
-     * @dev Checks if a transaction is approved by a wallet owner.
-     * @param txId The id of the transaction to check.
+     * @dev Returns the approval status of a transaction.
+     * @param txId The Id of the transaction to check.
      * @param owner The address of the wallet owner to check.
      * @return True if the transaction is approved.
      */
@@ -190,7 +189,7 @@ interface IMultiSigWallet is IMultiSigWalletTypes {
 
     /**
      * @dev Returns the number of approvals for a transaction.
-     * @param txId The id of the transaction to check.
+     * @param txId The Id of the transaction to check.
      */
     function getApprovalCount(uint256 txId) external view returns (uint256);
 
@@ -200,37 +199,35 @@ interface IMultiSigWallet is IMultiSigWalletTypes {
     function owners() external view returns (address[] memory);
 
     /**
-     * @dev Returns the minimum count of approvals required to execute a transaction.
+     * @dev Returns the number of approvals required to execute a transaction.
      */
     function requiredApprovals() external view returns (uint256);
 
     /**
-     * @dev Returns an array of submitted transactions.
-     * @param txId The id of the first transaction in the range to return.
+     * @dev Returns an array of transactions.
+     * @param txId The Id of the first transaction in the range to return.
      * @param limit The maximum number of transactions in the range to return.
      */
     function getTransactions(uint256 txId, uint256 limit) external view returns (Transaction[] memory);
 
     /**
-     * @dev Returns the details of a transaction.
-     * @param txId The id of the transaction to return.
+     * @dev Returns a single transaction.
+     * @param txId The Id of the transaction to return.
      */
     function getTransaction(uint256 txId) external view returns (Transaction memory);
 
     /**
-     * @dev Returns the length of the array of submitted transactions.
+     * @dev Returns the total number of transactions in the wallet.
      */
     function transactionCount() external view returns (uint256);
 
     /**
-     * @dev Returns the current cooldown time of transactions.
+     * @dev Returns the configured cooldown time.
      */
-    function transactionCooldownTime() external view returns (uint256);
     function cooldownTime() external view returns (uint256);
 
     /**
-     * @dev Returns the current expiration time of transactions.
+     * @dev Returns the configured expiration time.
      */
-    function transactionExpirationTime() external view returns (uint256);
     function expirationTime() external view returns (uint256);
 }

--- a/contracts/IMultiSigWallet.sol
+++ b/contracts/IMultiSigWallet.sol
@@ -211,6 +211,11 @@ interface IMultiSigWallet is IMultiSigWalletTypes {
     function owners() external view returns (address[] memory);
 
     /**
+     * @dev Checks if an account is configured as a wallet owner.
+     */
+    function isOwner(address account) external view returns (bool);
+
+    /**
      * @dev Returns the number of approvals required to execute a transaction.
      */
     function requiredApprovals() external view returns (uint256);

--- a/contracts/MultiSigWallet.sol
+++ b/contracts/MultiSigWallet.sol
@@ -503,7 +503,7 @@ contract MultiSigWallet is Initializable, MultiSigWalletStorage, IMultiSigWallet
      */
     function _configureExpirationTime(uint256 newExpirationTime) internal {
         _expirationTime = newExpirationTime;
-        emit CofigureExpirationTime(newExpirationTime);
+        emit ConfigureExpirationTime(newExpirationTime);
     }
 
     /**

--- a/contracts/MultiSigWallet.sol
+++ b/contracts/MultiSigWallet.sol
@@ -276,6 +276,9 @@ contract MultiSigWallet is Initializable, MultiSigWalletStorage, IMultiSigWallet
      * @dev See {IMultiSigWallet-getTransaction}.
      */
     function getTransaction(uint256 txId) external view returns (Transaction memory) {
+        if (txId >= _transactions.length) {
+            revert TransactionNotExist();
+        }
         return _transactions[txId];
     }
 

--- a/contracts/MultiSigWallet.sol
+++ b/contracts/MultiSigWallet.sol
@@ -470,8 +470,6 @@ contract MultiSigWallet is Initializable, MultiSigWalletStorage, IMultiSigWallet
         }
 
         uint256 len;
-        address owner;
-
         if (_owners.length != 0) {
             len = _owners.length;
             for (uint256 i = 0; i < len; i++) {
@@ -479,6 +477,7 @@ contract MultiSigWallet is Initializable, MultiSigWalletStorage, IMultiSigWallet
             }
         }
 
+        address owner;
         len = newOwners.length;
         for (uint256 i = 0; i < len; i++) {
             owner = newOwners[i];

--- a/contracts/MultiSigWallet.sol
+++ b/contracts/MultiSigWallet.sol
@@ -57,7 +57,7 @@ contract MultiSigWallet is Initializable, MultiSigWalletStorage, IMultiSigWallet
     // ------------------------- Modifiers --------------------------
 
     /**
-     * @dev Throws if called by any account other than the wallet owner.
+     * @dev Throws if called by any account other than a wallet owner.
      */
     modifier onlyOwner() {
         if (!_isOwner[msg.sender]) {

--- a/contracts/MultiSigWallet.sol
+++ b/contracts/MultiSigWallet.sol
@@ -312,6 +312,13 @@ contract MultiSigWallet is Initializable, MultiSigWalletStorage, IMultiSigWallet
     }
 
     /**
+     * @dev See {IMultiSigWallet-isOwner}.
+     */
+    function isOwner(address account) external view returns (bool) {
+        return _isOwner[account];
+    }
+
+    /**
      * @dev See {IMultiSigWallet-requiredApprovals}.
      */
     function requiredApprovals() external view returns (uint256) {

--- a/contracts/MultiSigWalletStorage.sol
+++ b/contracts/MultiSigWalletStorage.sol
@@ -18,20 +18,20 @@ abstract contract MultiSigWalletStorageV1 is IMultiSigWalletTypes {
     /// @dev The mapping of the ownership status for a given account.
     mapping(address => bool) internal _isOwner;
 
+    /// @dev The mapping of the number of approvals for a given transaction.
+    mapping(uint256 => uint256) internal _approvalCount;
+
     /// @dev The mapping of the approval status for a given owner and transaction.
     mapping(uint256 => mapping(address => bool)) internal _approvalStatus;
 
     /// @dev The number of approvals required to execute a transaction.
     uint256 internal _requiredApprovals;
 
-    /// @dev The amount of time that must elapse after a transaction is submitted before it can be executed.
-    uint256 internal _cooldownTime;
-
     /// @dev The amount of time after the cooldown period during which a transaction can be executed.
     uint256 internal _expirationTime;
 
-    /// @dev The mapping of the number of approvals for a given transaction.
-    mapping(uint256 => uint256) internal _approvalCount;
+    /// @dev The amount of time that must elapse after a transaction is submitted before it can be executed.
+    uint256 internal _cooldownTime;
 }
 
 /**

--- a/contracts/MultiSigWalletStorage.sol
+++ b/contracts/MultiSigWalletStorage.sol
@@ -19,16 +19,18 @@ abstract contract MultiSigWalletStorageV1 is IMultiSigWalletTypes {
     mapping(address => bool) internal _isOwner;
 
     /// @dev The mapping of an approval existence from a given account and transaction id.
-    mapping(uint256 => mapping(address => bool)) internal _approvals;
+    mapping(uint256 => mapping(address => bool)) internal _approvalStatus;
 
     /// @dev The number of approvals required to execute a transaction.
     uint256 internal _requiredApprovals;
 
     /// @dev The time that need to pass after submitting a transaction before it can be executed.
-    uint256 internal _transactionCooldownTime;
+    uint256 internal _cooldownTime;
 
     /// @dev The time after submitting a transaction before which it can be executed.
-    uint256 internal _transactionExpirationTime;
+    uint256 internal _expirationTime;
+
+    mapping(uint256 => uint256) internal _approvalCount;
 }
 
 /**

--- a/contracts/MultiSigWalletStorage.sol
+++ b/contracts/MultiSigWalletStorage.sol
@@ -5,7 +5,7 @@ pragma solidity 0.8.16;
 import { IMultiSigWalletTypes } from "./IMultiSigWallet.sol";
 
 /**
- * @title Multisignature wallet storage version 1
+ * @title MultiSigWallet storage - version 1
  * @author CloudWalk Inc.
  */
 abstract contract MultiSigWalletStorageV1 is IMultiSigWalletTypes {
@@ -15,21 +15,22 @@ abstract contract MultiSigWalletStorageV1 is IMultiSigWalletTypes {
     /// @dev The array of wallet transactions.
     Transaction[] internal _transactions;
 
-    /// @dev The mapping of a contract ownership status for a given account.
+    /// @dev The mapping of the ownership status for a given account.
     mapping(address => bool) internal _isOwner;
 
-    /// @dev The mapping of an approval existence from a given account and transaction id.
+    /// @dev The mapping of the approval status for a given owner and transaction.
     mapping(uint256 => mapping(address => bool)) internal _approvalStatus;
 
     /// @dev The number of approvals required to execute a transaction.
     uint256 internal _requiredApprovals;
 
-    /// @dev The time that need to pass after submitting a transaction before it can be executed.
+    /// @dev The amount of time that must elapse after a transaction is submitted before it can be executed.
     uint256 internal _cooldownTime;
 
-    /// @dev The time after submitting a transaction before which it can be executed.
+    /// @dev The amount of time after the cooldown period during which a transaction can be executed.
     uint256 internal _expirationTime;
 
+    /// @dev The mapping of the number of approvals for a given transaction.
     mapping(uint256 => uint256) internal _approvalCount;
 }
 

--- a/contracts/mock/TestContractMock.sol
+++ b/contracts/mock/TestContractMock.sol
@@ -13,6 +13,9 @@ contract TestContractMock {
     /// @dev Emitted when `testFunction` function is executed.
     event TestEvent(address sender, uint256 value, uint256 amount);
 
+    /// @dev A test error with some message
+    error TestError(string message);
+
     /**
      * @dev Test function.
      * Emits a {TestEvent} event.
@@ -21,7 +24,7 @@ contract TestContractMock {
     function testFunction(uint256 amount) external payable {
         emit TestEvent(msg.sender, msg.value, amount);
         if (_disabled) {
-            revert("Contract is disabled");
+            revert TestError("Contract is disabled");
         }
     }
 


### PR DESCRIPTION
### Main changes
1. The "owner" parameter has been added to the `Submit` and `Execute` events as we have for `Approve` and `Revoke` events.
2. Fields of the `Transaction` structure have been reordered.
3. The following storage variables have been renamed:
    * `_approvals` => `_approvalStatus`;
    * `_transactionCooldownTime` => `_cooldownTime`;
    * `_transactionExpirationTime` => `_expirationTime`.
4. The following functions has been renamed:
    * `configure()` => `configureOwners()`;
    * `updateCooldownTime()` => `configureCooldownTime()`;
    * `updateExpirationTime()` => `configureExpirationTime()`;
    * `transactionCooldownTime()` => `cooldownTime()`;
    * `transactionExpirationTime()` => `expirationTime()`;
    * `getApproval()` => `getApprovalStatus()`.
5. The following events have been renamed:
    * `Configure` => `ConfigureOwners`;
    * `CooldownTimeUpdate` => `ConfigureCooldownTime`;
    * `ExpirationTimeUpdate` => `ConfigureExpirationTime`.
6. The `MAX_OWNERS` constant has been removed along with the `OwnerCountExcess` error. Now the number of configured owners is not checked because the probability of configuring a very large number of owners is negligible. Also in any case the number is limited by the gas consumption of calling function `configureOwners()`.
7. The check of setting zero expiration time has been removed along with the `ZeroExpirationTime` error as redundant.
8. The logic of calculating the current number of approvals for a transaction has been chanded. Previously it was calculated by checking the approval status for each owner, now there is a separate storage variable (the `_approvalCount` map) that is increased each time when an approval is granted.
9. The `onlySelfCall()` modifier has been added to supervise that a transaction is sent by the wallet itself. The modifier replaces the appropriate internal function checks that were removed.
10. The `isOwner()` view function has been added to directly read the values from storage map `_isOwner`.
11. The check of expiration has been added to the `revoke()` function. Now an expired transaction can't be revoked, but previously it was possible.
12. The bug where the `_isOwner` map was not cleared when calling the `configureOwners()` function has been fixed. Now the map is being cleared. This functionality is covered by tests. 
13. Parameters of some functions have been renamed.
14. Comments in contracts have been improved.
15. The tests have been updated according to the changes in contracts. 
16. The tests (along with the mock contract) have been improved and more checks have been added to them. 

### Testing and coverage
The tests have been successfully run on the following blockchains:
1. Internal Hardhat net.
2. Substrate with Frontier layer built from the [cloudwalk-network](https://github.com/cloudwalk/cloudwalk-network) repo, commit [350445547016ce83c5ce781ac8871194439b0e4f](https://github.com/cloudwalk/cloudwalk-network/commit/350445547016ce83c5ce781ac8871194439b0e4f) with tag `mainnet-v1.0.2`.

_NOTE 1_: When running a local node of Substrate with Frontier layer for testing use the node in the archive mode like in the following command:
```bash
./target/release/cloudwalk-network-node --dev --tmp --pruning archive
```

Coverage:
![brlc-multisig-coverage](https://user-images.githubusercontent.com/97302011/211584012-dc2fafae-2ccb-46de-94b3-0f143bcec7a0.png)


