### PR TITLE
chore: comment ipmrovements

### DIFF
--- a/.cursor/rules/solidity-example-project.mdc
+++ b/.cursor/rules/solidity-example-project.mdc
@@ -1037,7 +1037,7 @@ contract AccessControlExtUpgradeableMock is AccessControlExtUpgradeable, UUPSUpg
     // ------------------ Initializers ---------------------------- //
 
     /**
-     * @dev The initialize function of the upgradeable contract.
+     * @dev Initializer of the upgradeable contract.
      *
      * See details: https://docs.openzeppelin.com/upgrades-plugins/writing-upgradeable
      */
@@ -1090,7 +1090,7 @@ contract PausableExtUpgradeableMock is PausableExtUpgradeable, UUPSUpgradeable {
     // ------------------ Initializers ---------------------------- //
 
     /**
-     * @dev The initialize function of the upgradeable contract.
+     * @dev Initializer of the upgradeable contract.
      *
      * See details: https://docs.openzeppelin.com/upgrades-plugins/writing-upgradeable
      */
@@ -1143,7 +1143,7 @@ contract RescuableUpgradeableMock is RescuableUpgradeable, UUPSUpgradeable {
     // ------------------ Initializers ---------------------------- //
 
     /**
-     * @dev The initialize function of the upgradeable contract.
+     * @dev Initializer of the upgradeable contract.
      *
      * See details: https://docs.openzeppelin.com/upgrades-plugins/writing-upgradeable
      */
@@ -1199,7 +1199,7 @@ contract UUPSExtUpgradeableMock is UUPSExtUpgradeable {
     // ------------------ Initializers ---------------------------- //
 
     /**
-     * @dev The initialize function of the upgradeable contract.
+     * @dev Initializer of the upgradeable contract.
      *
      * See details: https://docs.openzeppelin.com/upgrades-plugins/writing-upgradeable
      */

--- a/.cursor/rules/solidity-example-project.mdc
+++ b/.cursor/rules/solidity-example-project.mdc
@@ -422,7 +422,7 @@ abstract contract AccessControlExtUpgradeable is AccessControlUpgradeable {
     // ------------------ Initializers ---------------------------- //
 
     /**
-     * @dev The unchained internal initializer of the upgradeable contract
+     * @dev The unchained internal initializer of the upgradeable contract.
      *
      * See details: https://docs.openzeppelin.com/contracts/5.x/upgradeable#multiple-inheritance
      *
@@ -503,7 +503,7 @@ abstract contract PausableExtUpgradeable is AccessControlExtUpgradeable, Pausabl
     // ------------------ Initializers ---------------------------- //
 
     /**
-     * @dev The unchained internal initializer of the upgradeable contract
+     * @dev The unchained internal initializer of the upgradeable contract.
      *
      * See details: https://docs.openzeppelin.com/contracts/5.x/upgradeable#multiple-inheritance
      *
@@ -565,7 +565,7 @@ abstract contract RescuableUpgradeable is AccessControlExtUpgradeable {
     // ------------------ Initializers ---------------------------- //
 
     /**
-     * @dev The unchained internal initializer of the upgradeable contract
+     * @dev The unchained internal initializer of the upgradeable contract.
      *
      * See details: https://docs.openzeppelin.com/contracts/5.x/upgradeable#multiple-inheritance
      *

--- a/.cursor/rules/solidity-example-project.mdc
+++ b/.cursor/rules/solidity-example-project.mdc
@@ -367,11 +367,11 @@ abstract contract BlueprintStorageLayout is IBlueprintTypes {
     struct BlueprintStorage {
         // Slot 1
         address token;
-        // uint96 __reserved1; // Reserved for future use until the end of the storage slot
+        // uint96 __reserved1; // Reserved until the end of the storage slot
 
         // Slot 2
         address operationalTreasury;
-        // uint96 __reserved2; // Reserved for future use until the end of the storage slot
+        // uint96 __reserved2; // Reserved until the end of the storage slot
 
         // Slot 3
         mapping(bytes32 opId => Operation operation) operations;
@@ -948,7 +948,7 @@ interface IBlueprintTypes {
         OperationStatus status;
         address account;
         uint64 amount;
-        // uint24 __reserved; // Reserved for future use until the end of the storage slot
+        // uint24 __reserved; // Reserved until the end of the storage slot
     }
 
     /**
@@ -968,7 +968,7 @@ interface IBlueprintTypes {
         // Slot 2
         uint64 balance;
         uint32 operationCount;
-        // uint160 __reserved; // Reserved for future use until the end of the storage slot
+        // uint160 __reserved; // Reserved until the end of the storage slot
     }
 }
 ```

--- a/.cursor/rules/solidity-rules.mdc
+++ b/.cursor/rules/solidity-rules.mdc
@@ -218,7 +218,7 @@ alwaysApply: false
          uint8 status;
          address account;
          uint64 amount;
-         // uint24 __reserved; // Reserved for future use until the end of the storage slot
+         // uint24 __reserved; // Reserved until the end of the storage slot
      }
      ```
     
@@ -233,7 +233,7 @@ alwaysApply: false
         // Slot 2
         uint64 balance;
         uint32 operationCount;
-        // uint160 __reserved; // Reserved for future use until the end of the storage slot
+        // uint160 __reserved; // Reserved until the end of the storage slot
     }
     ```
 

--- a/contracts/MultiSigWalletUpgradeable.sol
+++ b/contracts/MultiSigWalletUpgradeable.sol
@@ -18,7 +18,7 @@ contract MultiSigWalletUpgradeable is Initializable, UUPSUpgradeable, MultiSigWa
     /**
      * @dev Constructor that prohibits the initialization of the implementation of the upgradeable contract.
      *
-     * See details
+     * See details:
      * https://docs.openzeppelin.com/upgrades-plugins/writing-upgradeable#initializing_the_implementation_contract
      *
      * @custom:oz-upgrades-unsafe-allow constructor
@@ -30,7 +30,7 @@ contract MultiSigWalletUpgradeable is Initializable, UUPSUpgradeable, MultiSigWa
     // ------------------ Initializers ---------------------------- //
 
     /**
-     * @dev The initializer of the upgradeable contract.
+     * @dev Initializer of the upgradeable contract.
      *
      * See details: https://docs.openzeppelin.com/upgrades-plugins/writing-upgradeable
      *
@@ -52,7 +52,7 @@ contract MultiSigWalletUpgradeable is Initializable, UUPSUpgradeable, MultiSigWa
     /**
      * @dev Upgrade authorization function.
      *
-     * See details: https://docs.openzeppelin.com/upgrades-plugins/1.x/writing-upgradeable
+     * See details: https://docs.openzeppelin.com/upgrades-plugins/writing-upgradeable
      *
      * @param newImplementation The address of the new implementation.
      *

--- a/contracts/MultiSigWalletUpgradeable.sol
+++ b/contracts/MultiSigWalletUpgradeable.sol
@@ -54,7 +54,7 @@ contract MultiSigWalletUpgradeable is Initializable, UUPSUpgradeable, MultiSigWa
      *
      * See details: https://docs.openzeppelin.com/upgrades-plugins/1.x/writing-upgradeable
      *
-     * @param newImplementation The address of the new implementation
+     * @param newImplementation The address of the new implementation.
      *
      * Requirements:
      *

--- a/contracts/base/IMultiSigWallet.sol
+++ b/contracts/base/IMultiSigWallet.sol
@@ -103,7 +103,7 @@ interface IMultiSigWallet is IMultiSigWalletTypes {
      * @param data The input data of the transaction.
      */
     function submit(
-        address to, // Tools: this comment prevents Prettier from formatting into a single line.
+        address to, // Tools: prevent Prettier one-liner
         uint256 value,
         bytes calldata data
     ) external;
@@ -119,7 +119,7 @@ interface IMultiSigWallet is IMultiSigWalletTypes {
      * @param data The input data of the transaction.
      */
     function submitAndApprove(
-        address to, // Tools: this comment prevents Prettier from formatting into a single line.
+        address to, // Tools: prevent Prettier one-liner
         uint256 value,
         bytes calldata data
     ) external;

--- a/contracts/base/MultiSigWalletBase.sol
+++ b/contracts/base/MultiSigWalletBase.sol
@@ -101,7 +101,7 @@ abstract contract MultiSigWalletBase is MultiSigWalletStorage, IMultiSigWallet {
      * - The caller must be a wallet owner.
      */
     function submit(
-        address to, // Tools: this comment prevents Prettier from formatting into a single line.
+        address to, // Tools: prevent Prettier one-liner
         uint256 value,
         bytes calldata data
     ) external onlyOwner {
@@ -116,7 +116,7 @@ abstract contract MultiSigWalletBase is MultiSigWalletStorage, IMultiSigWallet {
      * - The caller must be a wallet owner.
      */
     function submitAndApprove(
-        address to, // Tools: this comment prevents Prettier from formatting into a single line.
+        address to, // Tools: prevent Prettier one-liner
         uint256 value,
         bytes calldata data
     ) external onlyOwner {
@@ -390,7 +390,7 @@ abstract contract MultiSigWalletBase is MultiSigWalletStorage, IMultiSigWallet {
      * @dev Submits a transaction internally. See {MultiSigWallet-submit}.
      */
     function _submit(
-        address to, // Tools: this comment prevents Prettier from formatting into a single line.
+        address to, // Tools: prevent Prettier one-liner
         uint256 value,
         bytes calldata data
     ) internal returns (uint256 txId) {


### PR DESCRIPTION
# Main Changes

1. Fixed NatSpec comment styles.
2. Unified the format of NatSpec declarations for structs.
3. Standardized the NatSpec format for constructors and initializers.

Issue:
https://github.com/cloudwalk/product-smart-contracts/issues/199
